### PR TITLE
Se establece y verifica los límites del tablero

### DIFF
--- a/board/board.go
+++ b/board/board.go
@@ -2,8 +2,8 @@
 package board
 
 const (
-	Width  = 10
-	Height = 20
+	Width  = 10 // Ancho del tablero de Tetris
+	Height = 20 // Alto del tablero de Tetris
 )
 
 // Point representa un punto (coordenada x, y) en el tablero.
@@ -13,42 +13,69 @@ type Point struct {
 }
 
 // Board representa el tablero de juego.
-// Un valor de 0 puede significar celda vacía, y otros valores el tipo de figura.
+// Un valor de 0 significa celda vacía; otros valores indican el tipo de figura.
 type Board [Height][Width]int
 
 // NewBoard crea e inicializa un nuevo tablero de juego.
 func NewBoard() *Board {
 	b := &Board{}
-	// Aquí podrías inicializar todas las celdas a 0 (vacías)
+	// Todas las celdas se inicializan a 0 (vacías) por defecto en Go.
 	return b
 }
 
 // ClearLines verifica y limpia las líneas completas.
 // Retorna el número de líneas limpiadas.
 func (b *Board) ClearLines() int {
-	// Implementación para limpiar líneas
-	return 0
+	linesCleared := 0
+	// Recorrer el tablero de abajo hacia arriba
+	for y := Height - 1; y >= 0; y-- {
+		isFull := true
+		for x := 0; x < Width; x++ {
+			if b[y][x] == 0 {
+				isFull = false
+				break
+			}
+		}
+
+		if isFull {
+			linesCleared++
+			// Mover todas las líneas de arriba una posición hacia abajo
+			for moveY := y; moveY > 0; moveY-- {
+				for x := 0; x < Width; x++ {
+					b[moveY][x] = b[moveY-1][x]
+				}
+			}
+			// Limpiar la fila superior (ahora es nueva)
+			for x := 0; x < Width; x++ {
+				b[0][x] = 0
+			}
+			y++ // Volver a verificar la misma línea, ya que ha sido rellenada desde arriba
+		}
+	}
+	return linesCleared
 }
 
-// CheckCollision verifica si una figura colisiona con el tablero o con otras figuras.
-// Ahora espera []board.Point
-func (b *Board) CheckCollision(shapeBlocks []Point, x, y int) bool {
-	// Implementación para verificar colisiones
-	// Por ahora, una implementación simple que siempre dice que no hay colisión
-	// para que el código compile y puedas probar.
-	// Más adelante, aquí iría la lógica real.
-	_ = x // Usar x para evitar el error de variable no usada
-	_ = y // Usar y para evitar el error de variable no usada
-
+// CheckCollision verifica si una figura, en una posición dada (offsetX, offsetY),
+// colisionaría con los límites del tablero o con bloques ya existentes.
+func (b *Board) CheckCollision(shapeBlocks []Point, offsetX, offsetY int) bool {
 	for _, p := range shapeBlocks {
-		// Ejemplo de verificación de límites del tablero.
-		// La lógica completa de colisión debe implementarse aquí.
-		if p.Y < 0 || p.Y >= Height || p.X < 0 || p.X >= Width {
-			return true // Colisión con bordes del tablero
+		// Calcular la posición absoluta de cada bloque de la figura
+		absX := p.X + offsetX
+		absY := p.Y + offsetY
+
+		// 1. Colisión con los límites laterales o inferiores del tablero
+		if absX < 0 || absX >= Width || absY >= Height {
+			return true // Fuera de los límites del tablero
 		}
-		// Si la celda en el tablero ya está ocupada por otra figura
-		if b[p.Y][p.X] != 0 {
-			return true // Colisión con una figura existente
+
+		// 2. Colisión con la parte superior del tablero (permite aparecer)
+		// Si absY es menor que 0 (la figura está parcialmente fuera por arriba),
+		// no es una colisión válida de movimiento, solo de aparición.
+		// Solo verificamos colisiones con bloques existentes si absY está dentro del tablero.
+		if absY >= 0 {
+			if b[absY][absX] != 0 {
+				return true // Colisión con un bloque existente en el tablero
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Se establece y verifica los límites del tablero para el movimiento y la colisión de las figuras.

- Iteración por bloques de la figura: La función toma las coordenadas relativas de los bloques de la figura (shapeBlocks) y una posición de compensación (offsetX, offsetY).
- Cálculo de posición absoluta: Para cada bloque de la figura, se calcula su posición absoluta en el tablero (absX, absY).
- Verificación de límites laterales y inferiores:
-     absX < 0: Si el bloque se sale por el lado izquierdo.
-     absX >= Width: Si el bloque se sale por el lado derecho.
-     absY >= Height: Si el bloque se sale por la parte inferior.
Si cualquiera de estas condiciones es verdadera, hay una colisión con los límites del tablero.